### PR TITLE
For generatenewaddress specify currency code OR id

### DIFF
--- a/lib/cryptsy/api.rb
+++ b/lib/cryptsy/api.rb
@@ -138,9 +138,13 @@ module Cryptsy
                           price: price})
       end
 
-      def generatenewaddress(currencyid, currencycode)
-        call_private_api("generatenewaddress", {currencyid: currencyid,
-                                                currencycode: currencycode})
+      def generatenewaddress(currency)
+        # if integer - it is currency id
+        if currency.is_a? Integer or !!(currency =~ /^[-+]?[0-9]+$/)  then
+          call_private_api("generatenewaddress", {currencyid: currency})
+        else
+          call_private_api("generatenewaddress", {currencycode: currency})
+        end
       end
 
       private


### PR DESCRIPTION
API documentation is clear that code OR id should
be used, it does not have to be specified both.

Therefore, this patch would automatically detect
if ID or code is specified and call with relevant
parameter.
