### PR TITLE
Use marketdatav2 call in place of the new deprecated marketdata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+
+# Ruby Mine
+.idea/

--- a/lib/cryptsy/api.rb
+++ b/lib/cryptsy/api.rb
@@ -69,7 +69,7 @@ module Cryptsy
 
       # We don't bother to support deprecated v1 api
       def marketdata(marketid=nil)
-        call_public_api("marketdata", "singlemarketdata", marketid)
+        call_public_api("marketdatav2", "singlemarketdata", marketid)
       end
 
       def orderdata(marketid=nil)


### PR DESCRIPTION
The 'marketdata' call is being deprecated and gives a warning to use 'marketdatav2'.

The .gitignore update is just for Rubymine files.
