### PR TITLE
Add support for cryptsy 'getmydepositaddresses' private API method

### DIFF
--- a/lib/cryptsy/api.rb
+++ b/lib/cryptsy/api.rb
@@ -184,6 +184,10 @@ module Cryptsy
         call_private_api("makewithdrawal", {address: address, amount: amount})
       end
 
+      def getmydepositaddresses
+        call_private_api("getmydepositaddresses", {})
+      end
+
       private
         def call_public_api(all_markets, single_market, marketid=nil)
           Cryptsy::API::PublicMethod.new.execute_method(all_markets, single_market, marketid)

--- a/lib/cryptsy/api/version.rb
+++ b/lib/cryptsy/api/version.rb
@@ -1,5 +1,5 @@
 module Cryptsy
   module API
-    VERSION = "0.1.2"
+    VERSION = "0.1.3"
   end
 end


### PR DESCRIPTION
I couldn't find support for this API method - maybe it was recently added?
